### PR TITLE
Create tagging corpus from CoNNL data if it does not yet exist

### DIFF
--- a/scripts/train_test_tagger.sh
+++ b/scripts/train_test_tagger.sh
@@ -29,6 +29,19 @@ mkdir -p ${path_results}
 # Set file paths. Allow multiple test files.
 file_model=${path_models}/${language}_${suffix}.model
 file_train=${path_data}/${language}_train.conll.tagging
+
+#Create tagging corpus from CoNNL data if it does not yet exist
+if [ -e "${path_data}/${language}_train.conll" ] && [ ! -e "${path_data}/${language}_train.conll.tagging" ]; 
+then
+    ${path_bin}/scripts/create_tagging_corpus.sh "${path_data}/${language}_train.conll"
+    ${path_bin}/scripts/create_tagging_corpus.sh "${path_data}/${language}_test.conll"
+
+    if [ "$language" == "english_proj" ]
+    then
+        ${path_bin}/scripts/create_tagging_corpus.sh "${path_data}/${language}_dev.conll"
+    fi
+fi
+
 if [ "$language" == "english_proj" ]
 then
     files_test[0]=${path_data}/${language}_test.conll.tagging


### PR DESCRIPTION
This is a simple addition to the train_test_tagger.sh script, so that create_tagging_corpus.sh does not have to be run manually.
