### PR TITLE
Fix memory leak

### DIFF
--- a/src/classifier/Pipe.cpp
+++ b/src/classifier/Pipe.cpp
@@ -408,8 +408,9 @@ void Pipe::Run() {
     writer_->Write(output_instance);
 
     if (formatted_instance != instance) delete formatted_instance;
+    delete output_instance;
     delete instance;
-
+  
     instance = reader_->GetNext();
     ++num_instances;
   }


### PR DESCRIPTION
Delete output_instance after use to prevent memory leak, which can cause a crash on very long jobs.
