### PR TITLE
Fix CoNLL-X Shared Task links

### DIFF
--- a/README
+++ b/README
@@ -269,7 +269,7 @@ Here is a sample of two sentences from the Dutch dataset:
 12  terrassen         terras            N     N     soort|mv|neut                    11  cnj     _  _
 13  .                 .                 Punc  Punc  punt                             12  punct   _  _
 
-Please go to http://nextens.uvt.nl/~conll/#dataformat for more information 
+Please go to http://ilk.uvt.nl/conll/#dataformat for more information
 about the meaning of each column field. 
 The parser should still learn/run if some of the fields (like the FEATS field) 
 are filled with "_".
@@ -345,7 +345,7 @@ Just run:
   -s data/danish/danish_test.conll.predicted | tail -5
 
 This script also allows performing significance tests (see 
-http://nextens.uvt.nl/~conll/software.html for details).
+http://ilk.uvt.nl/conll/software.html for details).
 
 ================================================================================
 3c. Training the tagger

--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@ In Annual Meeting of the Association for Computational Linguistics (ACL'13), Sof
 The latest version of TurboParser is <a href="http://www.cs.cmu.edu/~afm/TurboParser/TurboParser-2.1.0.tar.gz">TurboParser v2.1.0 [~2.5MB,.tar.gz format]</a>. 
 See the <a href="http://www.cs.cmu.edu/~afm/TurboParser/README">README</a> file for instructions for compilation, running, and file formatting. 
 It does <i>not</i> include the data sets used in the papers; 
-for information about how to get these data sets, please go to <a href="http://nextens.uvt.nl/~conll">http://nextens.uvt.nl/~conll</a>. 
+for information about how to get these data sets, please go to <a href="http://ilk.uvt.nl/conll/">http://ilk.uvt.nl/conll/</a>.
 Bear in mind that some data sets must be separately licensed through the <a href="http://www.ldc.upenn.edu/">LDC</a>.
 </p>
 <p>


### PR DESCRIPTION
In some places links already point to http://ilk.uvt.nl/conll/, but not everywhere, so this commit fixes that.
