### PR TITLE
Ubuntu/Debian installer and some fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,9 @@ AC_SUBST(LFLAGS)
 AC_SUBST(CPPFLAGS)
 
 # Check for c++0x compile flag.
-AX_CHECK_COMPILE_FLAG([-std=c++0x], [CXXFLAGS="$CXXFLAGS -std=c++0x"])
+#AX_CHECK_COMPILE_FLAG([-std=c++0x], [CXXFLAGS="$CXXFLAGS -std=c++0x"])
+AX_CXX_COMPILE_STDCXX_11
+CXXFLAGS="$CXXFLAGS -std=c++11"
 
 # Macros
 # This will make ILOG use STL libs

--- a/install-ubuntu.sh
+++ b/install-ubuntu.sh
@@ -1,0 +1,19 @@
+#!/bin/bash                                                                                                                                                                                                        
+sudo apt-get install -y build-essential automake autoconf
+
+./install_deps.sh
+rm missing
+aclocal
+autoconf
+automake --add-missing
+./configure && make && make install
+
+sudo rm -rf /opt/TurboParser
+sudo cp -r "$PWD" /opt/TurboParser
+sudo ln -s /opt/TurboParser/Turbo* /usr/local/bin/
+
+echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/TurboParser/deps/local/lib:"  >> ~/.bashrc
+source ~/.bashrc
+echo
+echo "Installation finished"
+echo

--- a/install-ubuntu.sh
+++ b/install-ubuntu.sh
@@ -12,8 +12,8 @@ sudo rm -rf /opt/TurboParser
 sudo cp -r "$PWD" /opt/TurboParser
 sudo ln -s /opt/TurboParser/Turbo* /usr/local/bin/
 
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/TurboParser/deps/local/lib:
 echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/TurboParser/deps/local/lib:"  >> ~/.bashrc
-source ~/.bashrc
 echo
 echo "Installation finished"
 echo

--- a/src/coreference_resolver/Makefile.am
+++ b/src/coreference_resolver/Makefile.am
@@ -58,6 +58,7 @@ $(PARSER)/DependencyDictionary.h \
 $(PARSER)/DependencyInstanceNumeric.cpp \
 $(PARSER)/DependencyInstanceNumeric.h \
 $(SEQUENCE)/TokenDictionary.cpp $(SEQUENCE)/TokenDictionary.h \
+$(SEQUENCE)/SequenceInstance.cpp $(SEQUENCE)/SequenceInstance.h \
 $(CLASSIFIER)/Alphabet.cpp $(CLASSIFIER)/Dictionary.cpp \
 $(CLASSIFIER)/Features.h $(CLASSIFIER)/Options.h $(CLASSIFIER)/Part.h \
 $(CLASSIFIER)/Reader.cpp $(CLASSIFIER)/SparseParameterVector.h \

--- a/src/dependency_labeler/Makefile.am
+++ b/src/dependency_labeler/Makefile.am
@@ -27,6 +27,7 @@ $(PARSER)/DependencyWriter.h \
 $(PARSER)/DependencyInstanceNumeric.cpp \
 $(PARSER)/DependencyWriter.cpp \
 $(SEQUENCE)/TokenDictionary.cpp $(SEQUENCE)/TokenDictionary.h \
+$(SEQUENCE)/SequenceInstance.cpp $(SEQUENCE)/SequenceInstance.h \
 $(CLASSIFIER)/Alphabet.cpp $(CLASSIFIER)/Dictionary.cpp \
 $(CLASSIFIER)/Features.h $(CLASSIFIER)/Options.h $(CLASSIFIER)/Part.h \
 $(CLASSIFIER)/Reader.cpp $(CLASSIFIER)/SparseParameterVector.h \

--- a/src/parser/Makefile.am
+++ b/src/parser/Makefile.am
@@ -16,6 +16,7 @@ DependencyInstance.h DependencyPart.cpp DependencyReader.h FactorSequence.h \
 DependencyFeatures.cpp DependencyInstanceNumeric.cpp DependencyPart.h \
 DependencyWriter.cpp FactorTree.h \
 $(SEQUENCE)/TokenDictionary.cpp $(SEQUENCE)/TokenDictionary.h \
+$(SEQUENCE)/SequenceInstance.cpp $(SEQUENCE)/SequenceInstance.h \
 $(CLASSIFIER)/Alphabet.cpp $(CLASSIFIER)/Dictionary.cpp \
 $(CLASSIFIER)/Features.h $(CLASSIFIER)/Options.h $(CLASSIFIER)/Part.h \
 $(CLASSIFIER)/Reader.cpp $(CLASSIFIER)/SparseParameterVector.h \

--- a/src/semantic_parser/Makefile.am
+++ b/src/semantic_parser/Makefile.am
@@ -32,6 +32,7 @@ $(PARSER)/DependencyInstance.h \
 $(PARSER)/DependencyReader.cpp \
 $(PARSER)/DependencyReader.h \
 $(SEQUENCE)/TokenDictionary.cpp $(SEQUENCE)/TokenDictionary.h \
+$(SEQUENCE)/SequenceInstance.cpp $(SEQUENCE)/SequenceInstance.h \
 $(CLASSIFIER)/Alphabet.cpp $(CLASSIFIER)/Dictionary.cpp \
 $(CLASSIFIER)/Features.h $(CLASSIFIER)/Options.h $(CLASSIFIER)/Part.h \
 $(CLASSIFIER)/Reader.cpp $(CLASSIFIER)/SparseParameterVector.h \


### PR DESCRIPTION
@andre-martins and @davidalbertonogueira ,

I fixed some bugs I had found for trying to install the TurboParser under Debian distributions. The fixes were tested on clean installations for: debian jessie (8), ubuntu trusty (14.04), ubuntu wily (15.10) and ubuntu xenial (16.04). All of them the Turbo was installed without any problem.

I provided a installation script that also installs Turbo on /opt folder and create symbolic links in /usr/local/bin/

Best,

Pedro